### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,36 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.0) - 2024-06-13
+## [0.1.1](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.1) - 2024-06-13
 
-### Other
-- Add Cargo.toml fields
-- Add release-plz to repo
-- Update readme
-- Guard embedded-graphics color mapping behind feature gate
-- Fix color mapping
-- Add color mappings between Color and Rgb888
-- Add async support ([#5](https://github.com/avsaase/weact-studio-epd/pull/5))
-- Support for the other displays ([#3](https://github.com/avsaase/weact-studio-epd/pull/3))
-- Add clippy to ci
-- Setup basic actions ([#4](https://github.com/avsaase/weact-studio-epd/pull/4))
-- Add STM32G421 example to vscode settings
-- Example for STM32G4 ([#2](https://github.com/avsaase/weact-studio-epd/pull/2))
-- Update README.md
-- Update example
-- Make Drive generic over display size
-- Update readme
-- Add license
-- Cleanup
-- Update docs
-- Use Result alias
-- Update example
-- Fix quick refresh and add docs
-- Rename display
-- Remove VarDisplay
-- Cleanup example
-- Fix quick refresh in example
-- Try to get partial update to work
-- Try to get partial updates working
-- Don't run RA on root project mroe than once
-- Initial commit
+First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.0) - 2024-06-13
+
+### Other
+- Add Cargo.toml fields
+- Add release-plz to repo
+- Update readme
+- Guard embedded-graphics color mapping behind feature gate
+- Fix color mapping
+- Add color mappings between Color and Rgb888
+- Add async support ([#5](https://github.com/avsaase/weact-studio-epd/pull/5))
+- Support for the other displays ([#3](https://github.com/avsaase/weact-studio-epd/pull/3))
+- Add clippy to ci
+- Setup basic actions ([#4](https://github.com/avsaase/weact-studio-epd/pull/4))
+- Add STM32G421 example to vscode settings
+- Example for STM32G4 ([#2](https://github.com/avsaase/weact-studio-epd/pull/2))
+- Update README.md
+- Update example
+- Make Drive generic over display size
+- Update readme
+- Add license
+- Cleanup
+- Update docs
+- Use Result alias
+- Update example
+- Fix quick refresh and add docs
+- Rename display
+- Remove VarDisplay
+- Cleanup example
+- Fix quick refresh in example
+- Try to get partial update to work
+- Try to get partial updates working
+- Don't run RA on root project mroe than once
+- Initial commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weact-studio-epd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Alexander van Saase <avsaase@gmail.com>"]
 description = "Unofficial driver for WeAct Studio E-paper modules"

--- a/examples/rp2040/Cargo.lock
+++ b/examples/rp2040/Cargo.lock
@@ -1442,7 +1442,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "weact-studio-epd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "display-interface",
  "embedded-graphics",

--- a/examples/stm32g431/Cargo.lock
+++ b/examples/stm32g431/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "weact-studio-epd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "display-interface",
  "embedded-graphics",


### PR DESCRIPTION
## 🤖 New release
* `weact-studio-epd`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.0) - 2024-06-13

### Other
- Add Cargo.toml fields
- Add release-plz to repo
- Update readme
- Guard embedded-graphics color mapping behind feature gate
- Fix color mapping
- Add color mappings between Color and Rgb888
- Add async support ([#5](https://github.com/avsaase/weact-studio-epd/pull/5))
- Support for the other displays ([#3](https://github.com/avsaase/weact-studio-epd/pull/3))
- Add clippy to ci
- Setup basic actions ([#4](https://github.com/avsaase/weact-studio-epd/pull/4))
- Add STM32G421 example to vscode settings
- Example for STM32G4 ([#2](https://github.com/avsaase/weact-studio-epd/pull/2))
- Update README.md
- Update example
- Make Drive generic over display size
- Update readme
- Add license
- Cleanup
- Update docs
- Use Result alias
- Update example
- Fix quick refresh and add docs
- Rename display
- Remove VarDisplay
- Cleanup example
- Fix quick refresh in example
- Try to get partial update to work
- Try to get partial updates working
- Don't run RA on root project mroe than once
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).