### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.0) - 2024-07-27
+
+### Fixed
+- converting Color to BinaryColor ([#9](https://github.com/avsaase/weact-studio-epd/pull/9))
+
+### Other
+- Don't release before release PR is merged
+- Add Cargo.toml fields
+- Add release-plz to repo
+- Update readme
+- Guard embedded-graphics color mapping behind feature gate
+- Fix color mapping
+- Add color mappings between Color and Rgb888
+- Add async support ([#5](https://github.com/avsaase/weact-studio-epd/pull/5))
+- Support for the other displays ([#3](https://github.com/avsaase/weact-studio-epd/pull/3))
+- Add clippy to ci
+- Setup basic actions ([#4](https://github.com/avsaase/weact-studio-epd/pull/4))
+- Add STM32G421 example to vscode settings
+- Example for STM32G4 ([#2](https://github.com/avsaase/weact-studio-epd/pull/2))
+- Update README.md
+- Update example
+- Make Drive generic over display size
+- Update readme
+- Add license
+- Cleanup
+- Update docs
+- Use Result alias
+- Update example
+- Fix quick refresh and add docs
+- Rename display
+- Remove VarDisplay
+- Cleanup example
+- Fix quick refresh in example
+- Try to get partial update to work
+- Try to get partial updates working
+- Don't run RA on root project mroe than once
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `weact-studio-epd`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/avsaase/weact-studio-epd/releases/tag/v0.1.0) - 2024-07-27

### Fixed
- converting Color to BinaryColor ([#9](https://github.com/avsaase/weact-studio-epd/pull/9))

### Other
- Don't release before release PR is merged
- Add Cargo.toml fields
- Add release-plz to repo
- Update readme
- Guard embedded-graphics color mapping behind feature gate
- Fix color mapping
- Add color mappings between Color and Rgb888
- Add async support ([#5](https://github.com/avsaase/weact-studio-epd/pull/5))
- Support for the other displays ([#3](https://github.com/avsaase/weact-studio-epd/pull/3))
- Add clippy to ci
- Setup basic actions ([#4](https://github.com/avsaase/weact-studio-epd/pull/4))
- Add STM32G421 example to vscode settings
- Example for STM32G4 ([#2](https://github.com/avsaase/weact-studio-epd/pull/2))
- Update README.md
- Update example
- Make Drive generic over display size
- Update readme
- Add license
- Cleanup
- Update docs
- Use Result alias
- Update example
- Fix quick refresh and add docs
- Rename display
- Remove VarDisplay
- Cleanup example
- Fix quick refresh in example
- Try to get partial update to work
- Try to get partial updates working
- Don't run RA on root project mroe than once
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).