### PR TITLE
fix converting Color to BinaryColor

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -17,8 +17,8 @@ pub enum Color {
 impl From<BinaryColor> for Color {
     fn from(value: BinaryColor) -> Self {
         match value {
-            BinaryColor::Off => Color::White,
-            BinaryColor::On => Color::Black,
+            BinaryColor::On => Color::White,
+            BinaryColor::Off => Color::Black,
         }
     }
 }


### PR DESCRIPTION
Noticed images were coming out inverted when using `Bmp::<BinaryColor>::from_slice(bmp_image)` but correct when using `Bmp::<Rgb88>::from_slice(bmp_image)`