### PR TITLE
fix: pass display by reference not by value for tricolor displays

### DIFF
--- a/examples/rp2040/Cargo.lock
+++ b/examples/rp2040/Cargo.lock
@@ -1442,7 +1442,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "weact-studio-epd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "display-interface",
  "embedded-graphics",

--- a/examples/stm32g431/Cargo.lock
+++ b/examples/stm32g431/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "weact-studio-epd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "display-interface",
  "embedded-graphics",

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -472,7 +472,7 @@ where
     #[cfg(feature = "graphics")]
     pub async fn full_update<const BUFFER_SIZE: usize>(
         &mut self,
-        display: Display<WIDTH, HEIGHT, BUFFER_SIZE, TriColor>,
+        display: &Display<WIDTH, HEIGHT, BUFFER_SIZE, TriColor>,
     ) -> Result<()> {
         self.full_update_from_buffer(display.bw_buffer(), display.red_buffer())
             .await


### PR DESCRIPTION
When testing #14 with a tricolor display I noticed that the display was passed by value, not as a reference in full_update, which meant you could only ever update it once.